### PR TITLE
Add Result returns for cipher traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use cipher_crypt::ROT13;
 
 fn main(){
   let m = "I am my own inverse";
-  assert_eq!(m, ROT13::apply(&ROT13::apply(m).unwrap()).unwrap());
+  assert_eq!(m, ROT13::apply(&ROT13::apply(m)));
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ use cipher_crypt::ROT13;
 
 fn main(){
   let m = "I am my own inverse";
-  assert_eq!(m, ROT13::apply(&ROT13::apply(m)));
+  assert_eq!(m, ROT13::apply(&ROT13::apply(m).unwrap()).unwrap());
 }
 ```
 

--- a/src/caesar.rs
+++ b/src/caesar.rs
@@ -46,7 +46,7 @@ impl Cipher for Caesar {
         //         E(x) = (x + n) mod 26
         // Where;  x = position of letter in alphabet
         //         n = shift factor (or key)
-        Ok(substitute::shift_substitution(message, |idx| (idx + self.shift) % 26))
+        substitute::shift_substitution(message, |idx| (idx + self.shift) % 26)
     }
 
     /// Decrypt a message using a Caesar cipher.
@@ -72,7 +72,7 @@ impl Cipher for Caesar {
             //Rust does not natievly support negative wrap around modulo operations
         };
 
-        Ok(substitute::shift_substitution(cipher_text, decrypt))
+        substitute::shift_substitution(cipher_text, decrypt)
     }
 }
 
@@ -107,7 +107,7 @@ mod tests {
         //Test with every possible shift combination
         let message = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-        for i in 1..26 {
+        for i in 1..27 {
             let c = Caesar::new(i).unwrap();
             let encrypted = c.encrypt(message).unwrap();
             let decrypted = c.decrypt(&encrypted).unwrap();

--- a/src/caesar.rs
+++ b/src/caesar.rs
@@ -59,9 +59,9 @@ impl Cipher for Caesar {
     /// use cipher_crypt::Caesar;
     ///
     /// let c = Caesar::new(3).unwrap();
-    /// assert_eq!("Attack at dawn!", c.decrypt("Dwwdfn dw gdzq!"));
+    /// assert_eq!("Attack at dawn!", c.decrypt("Dwwdfn dw gdzq!").unwrap());
     /// ```
-    fn decrypt(&self, cipher_text: &str) -> String {
+    fn decrypt(&self, cipher_text: &str) -> Result<String, &'static str> {
         // Decryption of a letter:
         //         D(x) = (x - n) mod 26
         // Where;  x = position of letter in alphabet
@@ -72,7 +72,7 @@ impl Cipher for Caesar {
             //Rust does not natievly support negative wrap around modulo operations
         };
 
-        substitute::shift_substitution(cipher_text, decrypt)
+        Ok(substitute::shift_substitution(cipher_text, decrypt))
     }
 }
 
@@ -89,7 +89,7 @@ mod tests {
     #[test]
     fn decrypt_message() {
         let c = Caesar::new(2).unwrap();
-        assert_eq!("Attack at dawn!", c.decrypt("Cvvcem cv fcyp!"));
+        assert_eq!("Attack at dawn!", c.decrypt("Cvvcem cv fcyp!").unwrap());
     }
 
     #[test]
@@ -97,7 +97,7 @@ mod tests {
         let c = Caesar::new(3).unwrap();
         let message = "Peace, Freedom and Liberty! 🗡️";
         let encrypted = c.encrypt(message);
-        let decrypted = c.decrypt(&encrypted);
+        let decrypted = c.decrypt(&encrypted).unwrap();
 
         assert_eq!(decrypted, message);
     }
@@ -110,7 +110,7 @@ mod tests {
         for i in 1..26 {
             let c = Caesar::new(i).unwrap();
             let encrypted = c.encrypt(message);
-            let decrypted = c.decrypt(&encrypted);
+            let decrypted = c.decrypt(&encrypted).unwrap();
             assert_eq!(decrypted, message);
         }
     }

--- a/src/caesar.rs
+++ b/src/caesar.rs
@@ -39,14 +39,14 @@ impl Cipher for Caesar {
     /// use cipher_crypt::Caesar;
     ///
     /// let c = Caesar::new(3).unwrap();
-    /// assert_eq!("Dwwdfn dw gdzq!", c.encrypt("Attack at dawn!"));
+    /// assert_eq!("Dwwdfn dw gdzq!", c.encrypt("Attack at dawn!").unwrap());
     /// ```
-    fn encrypt(&self, message: &str) -> String {
+    fn encrypt(&self, message: &str) -> Result<String, &'static str> {
         // Encryption of a letter:
         //         E(x) = (x + n) mod 26
         // Where;  x = position of letter in alphabet
         //         n = shift factor (or key)
-        substitute::shift_substitution(message, |idx| (idx + self.shift) % 26)
+        Ok(substitute::shift_substitution(message, |idx| (idx + self.shift) % 26))
     }
 
     /// Decrypt a message using a Caesar cipher.
@@ -83,7 +83,7 @@ mod tests {
     #[test]
     fn encrypt_message() {
         let c = Caesar::new(2).unwrap();
-        assert_eq!("Cvvcem cv fcyp!", c.encrypt("Attack at dawn!"));
+        assert_eq!("Cvvcem cv fcyp!", c.encrypt("Attack at dawn!").unwrap());
     }
 
     #[test]
@@ -96,7 +96,7 @@ mod tests {
     fn with_emoji(){
         let c = Caesar::new(3).unwrap();
         let message = "Peace, Freedom and Liberty! 🗡️";
-        let encrypted = c.encrypt(message);
+        let encrypted = c.encrypt(message).unwrap();
         let decrypted = c.decrypt(&encrypted).unwrap();
 
         assert_eq!(decrypted, message);
@@ -109,7 +109,7 @@ mod tests {
 
         for i in 1..26 {
             let c = Caesar::new(i).unwrap();
-            let encrypted = c.encrypt(message);
+            let encrypted = c.encrypt(message).unwrap();
             let decrypted = c.decrypt(&encrypted).unwrap();
             assert_eq!(decrypted, message);
         }

--- a/src/common/cipher.rs
+++ b/src/common/cipher.rs
@@ -10,7 +10,7 @@ pub trait Cipher {
 
     /// Encrypt a `message` using a cipher's algorithm.
     ///
-    fn encrypt(&self, message: &str) -> String;
+    fn encrypt(&self, message: &str) -> Result<String, &'static str>;
 
     /// Decrypt a `message` using a cipher's algorithm.
     ///

--- a/src/common/cipher.rs
+++ b/src/common/cipher.rs
@@ -14,5 +14,5 @@ pub trait Cipher {
 
     /// Decrypt a `message` using a cipher's algorithm.
     ///
-    fn decrypt(&self, message: &str) -> String;
+    fn decrypt(&self, message: &str) -> Result<String, &'static str>;
 }

--- a/src/common/substitute.rs
+++ b/src/common/substitute.rs
@@ -6,7 +6,7 @@ use super::alphabet;
 /// within the alphabet.
 ///
 /// This substitution is defined by the closure `calc_index`
-pub fn shift_substitution<F>(text: &str, calc_index: F) -> String
+pub fn shift_substitution<F>(text: &str, calc_index: F) -> Result<String, &'static str>
     where F: Fn(usize) -> usize
 {
     let mut s_text = String::new();
@@ -20,13 +20,12 @@ pub fn shift_substitution<F>(text: &str, calc_index: F) -> String
                 if let Some(s) = alphabet::get_letter(si, c.is_uppercase()) {
                     s_text.push(s);
                 } else {
-                    //Something has gone wrong with indexing, just push char 'as-is'
-                    s_text.push(c);
+                    return Err("Calculated an index outside of the known alphabet.")
                 }
             },
             None => s_text.push(c), //Push non-alphabetic chars 'as-is'
         }
     }
 
-    s_text
+    Ok(s_text)
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //!   let m2 = "Attack at dawn 🗡️";
 //!   let c = Caesar::new(3).unwrap();
-//!   assert_eq!(m2, c.decrypt(&c.encrypt(m2)).unwrap());
+//!   assert_eq!(m2, c.decrypt(&c.encrypt(m2).unwrap()).unwrap());
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! fn main(){
 //!   let m1 = "I am my own inverse";
-//!   assert_eq!(m1, ROT13::apply(&ROT13::apply(m1).unwrap()).unwrap());
+//!   assert_eq!(m1, ROT13::apply(&ROT13::apply(m1)));
 //!
 //!   let m2 = "Attack at dawn 🗡️";
 //!   let c = Caesar::new(3).unwrap();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,7 @@
 //!
 //!   let m2 = "Attack at dawn 🗡️";
 //!   let c = Caesar::new(3).unwrap();
-//!   assert_eq!(m2, c.decrypt(&c.encrypt(m2)));
+//!   assert_eq!(m2, c.decrypt(&c.encrypt(m2)).unwrap());
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,7 +11,7 @@
 //!
 //! fn main(){
 //!   let m1 = "I am my own inverse";
-//!   assert_eq!(m1, ROT13::apply(&ROT13::apply(m1)));
+//!   assert_eq!(m1, ROT13::apply(&ROT13::apply(m1).unwrap()).unwrap());
 //!
 //!   let m2 = "Attack at dawn 🗡️";
 //!   let c = Caesar::new(3).unwrap();

--- a/src/railfence.rs
+++ b/src/railfence.rs
@@ -97,9 +97,9 @@ impl Cipher for Railfence {
     /// use cipher_crypt::Railfence;
     ///
     /// let r = Railfence::new(3).unwrap();
-    /// assert_eq!("Super-secret message!", r.decrypt("Src s!ue-ertmsaepseeg"));
+    /// assert_eq!("Super-secret message!", r.decrypt("Src s!ue-ertmsaepseeg").unwrap());
     /// ```
-    fn decrypt(&self, cipher_text: &str) -> String {
+    fn decrypt(&self, cipher_text: &str) -> Result<String, &'static str> {
         // Decryption process:
         //   First a table is created with a height given by the key and a length
         //   given by the ciphertext length.
@@ -122,7 +122,7 @@ impl Cipher for Railfence {
         // As mentioned previously, a single rail means that the original message has not been
         // altered
         if self.rails == 1 {
-            return cipher_text.to_string()
+            return Ok(cipher_text.to_string())
         }
 
         let mut table = vec![vec![(false, '.'); cipher_text.len()]; self.rails];
@@ -158,7 +158,7 @@ impl Cipher for Railfence {
             message.push(table[rail][col].1);
         }
 
-        message
+        Ok(message)
     }
 }
 
@@ -224,28 +224,28 @@ mod tests {
     fn decrypt_test() {
         let message = "awtantdatcak";
         let r = Railfence::new(6).unwrap();
-        assert_eq!("attackatdawn", r.decrypt(message));
+        assert_eq!("attackatdawn", r.decrypt(message).unwrap());
     }
 
     #[test]
     fn decrypt_short_key() {
         let message = "attackatdawn";
         let r = Railfence::new(1).unwrap();
-        assert_eq!("attackatdawn", r.decrypt(message));
+        assert_eq!("attackatdawn", r.decrypt(message).unwrap());
     }
 
     #[test]
     fn decrypt_mixed_case() {
         let message = "Hoo!el,Wrdl l";
         let r = Railfence::new(3).unwrap();
-        assert_eq!("Hello, World!", r.decrypt(message));
+        assert_eq!("Hello, World!", r.decrypt(message).unwrap());
     }
 
     #[test]
     fn decrypt_long_key() {
         let message = "attackatdawn";
         let r = Railfence::new(20).unwrap();
-        assert_eq!("attackatdawn", r.decrypt(message));
+        assert_eq!("attackatdawn", r.decrypt(message).unwrap());
     }
 
     #[test]

--- a/src/railfence.rs
+++ b/src/railfence.rs
@@ -38,9 +38,9 @@ impl Cipher for Railfence {
     /// use cipher_crypt::Railfence;
     ///
     /// let r = Railfence::new(3).unwrap();
-    /// assert_eq!("Src s!ue-ertmsaepseeg", r.encrypt("Super-secret message!"));
+    /// assert_eq!("Src s!ue-ertmsaepseeg", r.encrypt("Super-secret message!").unwrap());
     /// ```
-    fn encrypt(&self, message: &str) -> String {
+    fn encrypt(&self, message: &str) -> Result<String, &'static str> {
         // Encryption process:
         //   First a table is created with a height given by the key and a length
         //   given by the message length.
@@ -59,7 +59,7 @@ impl Cipher for Railfence {
         // We simply return the message as the 'encrypted' message when there is one rail.
         // This is because the message is transposed along a single rail without being altered.
         if self.rails == 1 {
-            return message.to_string()
+            return Ok(message.to_string())
         }
 
         // Initialise the fence (a simple table)
@@ -84,7 +84,7 @@ impl Cipher for Railfence {
             }
         }
 
-        cipher_text
+        Ok(cipher_text)
     }
 
     /// Decrypt a message using a Railfence cipher.
@@ -196,28 +196,28 @@ mod tests {
     fn encrypt_test() {
         let message = "attackatdawn";
         let r = Railfence::new(6).unwrap();
-        assert_eq!("awtantdatcak", r.encrypt(message));
+        assert_eq!("awtantdatcak", r.encrypt(message).unwrap());
     }
 
     #[test]
     fn encrypt_mixed_case() {
         let message = "Hello, World!";
         let r = Railfence::new(3).unwrap();
-        assert_eq!("Hoo!el,Wrdl l", r.encrypt(message));
+        assert_eq!("Hoo!el,Wrdl l", r.encrypt(message).unwrap());
     }
 
     #[test]
     fn encrypt_short_key() {
         let message = "attackatdawn";
         let r = Railfence::new(1).unwrap();
-        assert_eq!("attackatdawn", r.encrypt(message));
+        assert_eq!("attackatdawn", r.encrypt(message).unwrap());
     }
 
     #[test]
     fn encrypt_long_key() {
         let message = "attackatdawn";
         let r = Railfence::new(20).unwrap();
-        assert_eq!("attackatdawn", r.encrypt(message));
+        assert_eq!("attackatdawn", r.encrypt(message).unwrap());
     }
 
     #[test]
@@ -257,6 +257,6 @@ mod tests {
     fn unicode_test() {
         let r = Railfence::new(3).unwrap();
         let message = "ÂƮƮäƈķ ɑƬ Ðawŋ ✓";
-        assert_eq!("ÂƈƬwƮäķɑ aŋ✓Ʈ Ð ", r.encrypt(message));
+        assert_eq!("ÂƈƬwƮäķɑ aŋ✓Ʈ Ð ", r.encrypt(message).unwrap());
     }
 }

--- a/src/rot13.rs
+++ b/src/rot13.rs
@@ -15,10 +15,12 @@ use common::substitute;
 /// use cipher_crypt::ROT13;
 ///
 /// let m = "I am my own inverse";
-/// assert_eq!(m, ROT13::apply(&ROT13::apply(m).unwrap()).unwrap());
+/// assert_eq!(m, ROT13::apply(&ROT13::apply(m)));
 /// ```
-pub fn apply(message: &str) -> Result<String, &'static str> {
-    substitute::shift_substitution(message, |i| (i + 13) % 26)
+pub fn apply(message: &str) -> String {
+    // The closure below is guarenteed to produce a number less than 26, therefore the
+    // substitution will not return an error and we can unwrap safely.
+    substitute::shift_substitution(message, |i| (i + 13) % 26).unwrap()
 }
 
 #[cfg(test)]
@@ -28,8 +30,8 @@ mod tests {
     #[test]
     fn with_emoji(){
         let message = "Peace, Freedom and Liberty! 🗡️";
-        let encrypted = apply(message).unwrap();
-        let decrypted = apply(&encrypted).unwrap();
+        let encrypted = apply(message);
+        let decrypted = apply(&encrypted);
 
         assert_eq!(decrypted, message);
     }
@@ -38,8 +40,8 @@ mod tests {
     fn alphabet_encrypt(){
         let message = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-        let encrypted = apply(message).unwrap();
-        let decrypted = apply(&encrypted).unwrap();
+        let encrypted = apply(message);
+        let decrypted = apply(&encrypted);
 
         assert_eq!(decrypted, message);
     }

--- a/src/rot13.rs
+++ b/src/rot13.rs
@@ -15,9 +15,9 @@ use common::substitute;
 /// use cipher_crypt::ROT13;
 ///
 /// let m = "I am my own inverse";
-/// assert_eq!(m, ROT13::apply(&ROT13::apply(m)));
+/// assert_eq!(m, ROT13::apply(&ROT13::apply(m).unwrap()).unwrap());
 /// ```
-pub fn apply(message: &str) -> String {
+pub fn apply(message: &str) -> Result<String, &'static str> {
     substitute::shift_substitution(message, |i| (i + 13) % 26)
 }
 
@@ -28,8 +28,8 @@ mod tests {
     #[test]
     fn with_emoji(){
         let message = "Peace, Freedom and Liberty! 🗡️";
-        let encrypted = apply(message);
-        let decrypted = apply(&encrypted);
+        let encrypted = apply(message).unwrap();
+        let decrypted = apply(&encrypted).unwrap();
 
         assert_eq!(decrypted, message);
     }
@@ -38,8 +38,8 @@ mod tests {
     fn alphabet_encrypt(){
         let message = "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ";
 
-        let encrypted = apply(message);
-        let decrypted = apply(&encrypted);
+        let encrypted = apply(message).unwrap();
+        let decrypted = apply(&encrypted).unwrap();
 
         assert_eq!(decrypted, message);
     }

--- a/src/vigenere.rs
+++ b/src/vigenere.rs
@@ -45,16 +45,16 @@ impl Cipher for Vigenere {
     /// use cipher_crypt::Vigenere;
     ///
     /// let v = Vigenere::new(String::from("giovan")).unwrap();
-    /// assert_eq!("O bzvrx uzt gvm ceklwo!", v.encrypt("I never get any credit!"));
+    /// assert_eq!("O bzvrx uzt gvm ceklwo!", v.encrypt("I never get any credit!").unwrap());
     /// ```
-    fn encrypt(&self, message: &str) -> String {
+    fn encrypt(&self, message: &str) -> Result<String, &'static str> {
         // Encryption of a letter in a message:
         //         Ci = Ek(Mi) = (Mi + Ki) mod 26
         // Where;  Mi = position within the alphabet of ith char in message
         //         Ki = position within the alphabet of ith char in key
         let e_key = self.fit_key(message.len());
 
-        Vigenere::poly_substitute(message, e_key, |mi, ki| (mi + ki) % 26)
+        Ok(Vigenere::poly_substitute(message, e_key, |mi, ki| (mi + ki) % 26))
     }
 
     /// Decrypt a message using a Vigenère cipher.
@@ -155,7 +155,7 @@ mod tests {
     fn encrypt_test() {
         let message = "attackatdawn";
         let v = Vigenere::new(String::from("lemon")).unwrap();
-        assert_eq!("lxfopvefrnhr", v.encrypt(message));
+        assert_eq!("lxfopvefrnhr", v.encrypt(message).unwrap());
     }
 
     #[test]
@@ -170,7 +170,7 @@ mod tests {
         let message = "Attack at Dawn!";
         let v = Vigenere::new(String::from("giovan")).unwrap();
 
-        let cipher_text = v.encrypt(message);
+        let cipher_text = v.encrypt(message).unwrap();
         let plain_text = v.decrypt(&cipher_text).unwrap();
 
         assert_eq!(plain_text, message);
@@ -180,7 +180,7 @@ mod tests {
     fn with_emoji(){
         let v = Vigenere::new(String::from("emojisarefun")).unwrap();
         let message = "Peace, Freedom and Liberty! 🗡️";
-        let encrypted = v.encrypt(message);
+        let encrypted = v.encrypt(message).unwrap();
         let decrypted = v.decrypt(&encrypted).unwrap();
 
         assert_eq!(decrypted, message);

--- a/src/vigenere.rs
+++ b/src/vigenere.rs
@@ -67,9 +67,9 @@ impl Cipher for Vigenere {
     /// use cipher_crypt::Vigenere;
     ///
     /// let v = Vigenere::new(String::from("giovan")).unwrap();
-    /// assert_eq!("I never get any credit!", v.decrypt("O bzvrx uzt gvm ceklwo!"));
+    /// assert_eq!("I never get any credit!", v.decrypt("O bzvrx uzt gvm ceklwo!").unwrap());
     /// ```
-    fn decrypt(&self, cipher_text: &str) -> String {
+    fn decrypt(&self, cipher_text: &str) -> Result<String, &'static str> {
         // Decryption of a letter in a message:
         //         Mi = Dk(Ci) = (Ci - Ki) mod 26
         // Where;  Ci = position within the alphabet of ith char in cipher text
@@ -82,7 +82,7 @@ impl Cipher for Vigenere {
             //Rust does not natievly support negative wrap around modulo operations
         };
 
-        Vigenere::poly_substitute(cipher_text, d_key, decrypt)
+        Ok(Vigenere::poly_substitute(cipher_text, d_key, decrypt))
     }
 }
 
@@ -162,7 +162,7 @@ mod tests {
     fn decrypt_test() {
         let cipher_text = "lxfopvefrnhr";
         let v = Vigenere::new(String::from("lemon")).unwrap();
-        assert_eq!("attackatdawn", v.decrypt(cipher_text));
+        assert_eq!("attackatdawn", v.decrypt(cipher_text).unwrap());
     }
 
     #[test]
@@ -171,7 +171,7 @@ mod tests {
         let v = Vigenere::new(String::from("giovan")).unwrap();
 
         let cipher_text = v.encrypt(message);
-        let plain_text = v.decrypt(&cipher_text);
+        let plain_text = v.decrypt(&cipher_text).unwrap();
 
         assert_eq!(plain_text, message);
     }
@@ -181,7 +181,7 @@ mod tests {
         let v = Vigenere::new(String::from("emojisarefun")).unwrap();
         let message = "Peace, Freedom and Liberty! 🗡️";
         let encrypted = v.encrypt(message);
-        let decrypted = v.decrypt(&encrypted);
+        let decrypted = v.decrypt(&encrypted).unwrap();
 
         assert_eq!(decrypted, message);
     }


### PR DESCRIPTION
I've added result return types for both the encrypt and decrypt traits, and have added unwraps everywhere in the tests and docstrings. So many unwraps. Currently, none of the ciphers actually return an Err.