### PR TITLE
Issue 30 - implementation for columnar_transposition and advgvx

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 target/
 **/*.rs.bk
 Cargo.lock
-main.rs
-clippy.txt

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ target/
 **/*.rs.bk
 Cargo.lock
 main.rs
+clippy.txt

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 target/
 **/*.rs.bk
 Cargo.lock
+main.rs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher-crypt"
-version = "0.11.0"
+version = "0.12.0"
 authors = ["arosspope <andrew.pope456@gmail.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/arosspope/cipher-crypt.git"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ adding the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-cipher-crypt = "^0.11"
+cipher-crypt = "^0.12"
 ```
 
 Using the crate as such:

--- a/src/adfgvx.rs
+++ b/src/adfgvx.rs
@@ -1,5 +1,4 @@
-//! The ADFGVX cipher was a field cipher used by the German Army on the Western Front during World
-//! War I.
+//! The ADFGVX cipher was a field cipher used by the German Army on the Western Front during World War I.
 //!
 //! ADFGVX was an extension of an earlier cipher called ADFGX. It uses a polybius square and a
 //! columnar transposition cipher.
@@ -77,9 +76,9 @@ impl Cipher for ADFGVX {
     ///
     fn encrypt(&self, message: &str) -> Result<String, &'static str> {
         //Step 1: encrypt using polybius
-        let round_one = self.polybius_cipher.encrypt(message)?;
+        let step_one = self.polybius_cipher.encrypt(message)?;
         //Step 2: encrypt with columnar and return
-        self.columnar_cipher.encrypt(&round_one)
+        self.columnar_cipher.encrypt(&step_one)
     }
 
     /// Decrypt a message using a ADFGVX cipher.
@@ -113,9 +112,9 @@ impl Cipher for ADFGVX {
     ///
     fn decrypt(&self, ciphertext: &str) -> Result<String, &'static str> {
         //Step 1: decrypt using columnar
-        let round_one = self.columnar_cipher.decrypt(ciphertext)?;
+        let step_one = self.columnar_cipher.decrypt(ciphertext)?;
         //Step 2: decrypt using polybius
-        self.polybius_cipher.decrypt(&round_one)
+        self.polybius_cipher.decrypt(&step_one)
     }
 }
 
@@ -238,7 +237,7 @@ mod tests {
     }
 
     #[test]
-    fn plaintext_with_padding(){
+    fn plaintext_with_padding() {
         let a = ADFGVX::new((
             String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
             String::from("VICTORY"),

--- a/src/adfgvx.rs
+++ b/src/adfgvx.rs
@@ -16,23 +16,27 @@ const ADFGVX_CHARS: [char; 6] = ['A', 'D', 'F', 'G', 'V', 'X'];
 pub struct ADFGVX {
     key: String,
     keyword: String,
+    null_char: String,
 }
 
 impl Cipher for ADFGVX {
-    type Key = (String, String);
+    type Key = (String, String, String);
     type Algorithm = ADFGVX;
 
     /// Initialise a ADFGVX cipher.
     /// All we are interested in is:
     ///  - The 36 character key that will be stored in the Polybius square
     ///  - The keyword that will be used to transpose the output of the Polybius square function
+    ///  - An optional `null_char` that will be used for the `ColumnarTransposition`
     ///
-    fn new(key: (String, String)) -> Result<ADFGVX, &'static str> {
+    fn new(key: (String, String, String)) -> Result<ADFGVX, &'static str> {
         // Check the validity of the key
         keygen::keyed_alphabet(&key.0, alphabet::ALPHANUMERIC, false)?;
+
         Ok(ADFGVX {
             key: key.0,
             keyword: key.1,
+            null_char: key.2,
         })
     }
 
@@ -44,9 +48,14 @@ impl Cipher for ADFGVX {
     /// ```
     /// use cipher_crypt::{Cipher, ADFGVX};
     ///
+    /// let key = String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8");
+    /// let key_word = String::from("GERMAN");
+    /// let null_char = String::from("");
+    ///
     /// let a = ADFGVX::new((
-    ///     "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
-    ///     "GERMAN".to_string(),
+    ///     key,
+    ///     key_word,
+    ///     null_char
     /// )).unwrap();
     ///
     /// let cipher_text = concat!(
@@ -65,6 +74,7 @@ impl Cipher for ADFGVX {
         // Can't get around the borrowing here...
         let key = self.key.clone();
         let keyword = self.keyword.clone();
+        let null_char = self.null_char.clone();
 
         // Two steps to encrypt
         //  1. Create a polybius square
@@ -72,7 +82,7 @@ impl Cipher for ADFGVX {
         // Encrypt with this
         let initial_ciphertext = p.encrypt(message).unwrap();
         //  2. Columnar transposition
-        let ct = ColumnarTransposition::new((keyword, String::from(""))).unwrap();
+        let ct = ColumnarTransposition::new((keyword, null_char)).unwrap();
         // Encrypt with this
         let ciphertext = ct.encrypt(&initial_ciphertext).unwrap();
 
@@ -87,9 +97,14 @@ impl Cipher for ADFGVX {
     /// ```
     /// use cipher_crypt::{Cipher, ADFGVX};
     ///
+    /// let key = String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8");
+    /// let key_word = String::from("GERMAN");
+    /// let null_char = String::from("");
+    ///
     /// let a = ADFGVX::new((
-    ///     "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
-    ///     "GERMAN".to_string(),
+    ///     key,
+    ///     key_word,
+    ///     null_char
     /// )).unwrap();
     ///
     /// let cipher_text = concat!(
@@ -106,10 +121,10 @@ impl Cipher for ADFGVX {
     fn decrypt(&self, ciphertext: &str) -> Result<String, &'static str> {
         let key = self.key.clone();
         let keyword = self.keyword.clone();
-
+        let null_char = self.null_char.clone();
         // Two steps to decrypt:
         // 1. Create a ColumnarTransposition and decrypt
-        let ct = ColumnarTransposition::new((keyword, String::from(""))).unwrap();
+        let ct = ColumnarTransposition::new((keyword, null_char)).unwrap();
         let round_one = ct.decrypt(ciphertext).unwrap();
         // 2. Create a Polybius square and decrypt
         let p = Polybius::new((key.to_string(), ADFGVX_CHARS, ADFGVX_CHARS)).unwrap();
@@ -125,23 +140,37 @@ mod tests {
 
     #[test]
     fn encrypt_message() {
-        //     A D F G V X
-        //  A| p h 0 q g 6
-        //  D| 4 m e a 1 y
-        //  F| l 2 n o f d
-        //  G| x k r 3 c v
-        //  V| s 5 z w 7 b
-        //  X| j 9 u t i 8
         let a = ADFGVX::new((
-            "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
-            "GERMAN".to_string(),
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("GERMAN"),
+            String::from(""),
         )).unwrap();
 
         let cipher_text = concat!(
             "gfxffgxgDFAXDAVGDgxvadaaxxXFDDFGGGFdfaxdavgdVDAGFAX",
             "VVxfddfgggfVVVAGFFAvvvagffaGXVADAAXXvdagfaxvvGFXFFGXG"
         );
-        // Only if no null is used - different cipher text otherwise
+        assert_eq!(
+            cipher_text,
+            a.encrypt("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
+                .unwrap()
+        );
+    }
+
+    #[test]
+    fn encrypt_message_with_whitespace_nulls() {
+        let a = ADFGVX::new((
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("GERMAN"),
+            String::from(" "),
+        )).unwrap();
+
+        // Note: this works as per crate version 0.11.0 - and leaves a trailing
+        //       ' ' in the ciphertext.
+        let cipher_text = concat!(
+            "gfxffgxgDFAXDAVGD gxvadaaxxXFDDFGGGFdfaxdavgdVDAGFAX",
+            "VVxfddfgggfVVVAGFFA vvvagffaGXVADAAXX vdagfaxvvGFXFFGXG "
+        );
         assert_eq!(
             cipher_text,
             a.encrypt("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -152,13 +181,34 @@ mod tests {
     #[test]
     fn decrypt_message() {
         let a = ADFGVX::new((
-            "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
-            "GERMAN".to_string(),
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("GERMAN"),
+            String::from(""),
         )).unwrap();
 
         let cipher_text = concat!(
-            "gfxffgxgDFAXDAVGD gxvadaaxxXFDDFGGGFdfaxdav",
-            "gdVDAGFAXVVxfddfgggfVVVAGFFA vvvagffaGXVADAAXX vdagfaxvvGFXFFGXG "
+            "gfxffgxgDFAXDAVGDgxvadaaxxXFDDFGGGFdfaxdavgdVDAGFAX",
+            "VVxfddfgggfVVVAGFFAvvvagffaGXVADAAXXvdagfaxvvGFXFFGXG"
+        );
+        assert_eq!(
+            "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
+            a.decrypt(cipher_text).unwrap()
+        );
+    }
+
+    #[test]
+    fn decrypt_message_with_whitespace_nulls() {
+        let a = ADFGVX::new((
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("GERMAN"),
+            String::from(" "),
+        )).unwrap();
+
+        // Note: this works as per crate version 0.11.0 - and leaves a trailing
+        //       ' ' in the ciphertext.
+        let cipher_text = concat!(
+            "gfxffgxgDFAXDAVGD gxvadaaxxXFDDFGGGFdfaxdavgdVDAGFAX",
+            "VVxfddfgggfVVVAGFFA vvvagffaGXVADAAXX vdagfaxvvGFXFFGXG "
         );
         assert_eq!(
             "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ",
@@ -169,8 +219,45 @@ mod tests {
     #[test]
     fn encrypt_decrypt_message() {
         let a = ADFGVX::new((
-            "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
-            "VICTORY".to_string(),
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("VICTORY"),
+            String::from(""),
+        )).unwrap();
+
+        let plain_text = concat!(
+            "We attack at dawn, not later when it is light, ",
+            "or at some strange time of the clock. Only at dawn."
+        );
+        assert_eq!(
+            a.decrypt(&a.encrypt(plain_text).unwrap()).unwrap(),
+            plain_text
+        );
+    }
+
+    #[test]
+    fn encrypt_decrypt_message_with_nulls() {
+        let a = ADFGVX::new((
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("VICTORY"),
+            String::from("\u{0}"),
+        )).unwrap();
+
+        let plain_text = concat!(
+            "We attack at dawn, not later when it is light, ",
+            "or at some strange time of the clock. Only at dawn."
+        );
+        assert_eq!(
+            a.decrypt(&a.encrypt(plain_text).unwrap()).unwrap(),
+            plain_text
+        );
+    }
+
+    #[test]
+    fn encrypt_decrypt_message_null_space() {
+        let a = ADFGVX::new((
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("VICTORY"),
+            String::from(" "),
         )).unwrap();
 
         let plain_text = concat!(
@@ -187,8 +274,24 @@ mod tests {
     fn with_utf8() {
         let plain_text = "Attack 🗡️ the east wall";
         let a = ADFGVX::new((
-            "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
-            "GERMAN".to_string(),
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("GERMAN"),
+            String::from(""),
+        )).unwrap();
+
+        assert_eq!(
+            plain_text,
+            a.decrypt(&a.encrypt(plain_text).unwrap()).unwrap()
+        );
+    }
+
+    #[test]
+    fn with_utf8_with_nulls() {
+        let plain_text = "Attack 🗡️ the east wall";
+        let a = ADFGVX::new((
+            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
+            String::from("GERMAN"),
+            String::from("\u{0}"),
         )).unwrap();
 
         assert_eq!(
@@ -199,7 +302,13 @@ mod tests {
 
     #[test]
     fn invalid_key_phrase() {
-        assert!(ADFGVX::new(("F@il".to_string(), "GERMAN".to_string())).is_err());
+        assert!(
+            ADFGVX::new((
+                String::from("F@il"),
+                String::from("GERMAN"),
+                String::from("")
+            )).is_err()
+        );
     }
 
 }

--- a/src/adfgvx.rs
+++ b/src/adfgvx.rs
@@ -50,8 +50,8 @@ impl Cipher for ADFGVX {
     /// )).unwrap();
     ///
     /// let cipher_text = concat!(
-    ///     "gfxffgxgDFAXDAVGD gxvadaaxxXFDDFGGGFdfaxdav",
-    ///     "gdVDAGFAXVVxfddfgggfVVVAGFFA vvvagffaGXVADAAXX vdagfaxvvGFXFFGXG "
+    ///     "gfxffgxgDFAXDAVGDgxvadaaxxXFDDFGGGFdfaxdavgdVDAGFAXVVxfdd",
+    ///     "fgggfVVVAGFFAvvvagffaGXVADAAXXvdagfaxvvGFXFFGXG"
     /// );
     ///
     /// assert_eq!(
@@ -72,9 +72,8 @@ impl Cipher for ADFGVX {
         // Encrypt with this
         let initial_ciphertext = p.encrypt(message).unwrap();
         //  2. Columnar transposition
-        let ct = ColumnarTransposition::new(keyword).unwrap();
+        let ct = ColumnarTransposition::new((keyword, String::from(""))).unwrap();
         // Encrypt with this
-        // TODO: Issue is that it is adding in spurious ' ' white space chars...
         let ciphertext = ct.encrypt(&initial_ciphertext).unwrap();
 
         Ok(ciphertext)
@@ -110,7 +109,7 @@ impl Cipher for ADFGVX {
 
         // Two steps to decrypt:
         // 1. Create a ColumnarTransposition and decrypt
-        let ct = ColumnarTransposition::new(keyword).unwrap();
+        let ct = ColumnarTransposition::new((keyword, String::from(""))).unwrap();
         let round_one = ct.decrypt(ciphertext).unwrap();
         // 2. Create a Polybius square and decrypt
         let p = Polybius::new((key.to_string(), ADFGVX_CHARS, ADFGVX_CHARS)).unwrap();
@@ -139,9 +138,10 @@ mod tests {
         )).unwrap();
 
         let cipher_text = concat!(
-            "gfxffgxgDFAXDAVGD gxvadaaxxXFDDFGGGFdfaxdav",
-            "gdVDAGFAXVVxfddfgggfVVVAGFFA vvvagffaGXVADAAXX vdagfaxvvGFXFFGXG "
+            "gfxffgxgDFAXDAVGDgxvadaaxxXFDDFGGGFdfaxdavgdVDAGFAX",
+            "VVxfddfgggfVVVAGFFAvvvagffaGXVADAAXXvdagfaxvvGFXFFGXG"
         );
+        // Only if no null is used - different cipher text otherwise
         assert_eq!(
             cipher_text,
             a.encrypt("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ")
@@ -167,14 +167,34 @@ mod tests {
     }
 
     #[test]
+    fn encrypt_decrypt_message() {
+        let a = ADFGVX::new((
+            "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
+            "VICTORY".to_string(),
+        )).unwrap();
+
+        let plain_text = concat!(
+            "We attack at dawn, not later when it is light, ",
+            "or at some strange time of the clock. Only at dawn."
+        );
+        assert_eq!(
+            a.decrypt(&a.encrypt(plain_text).unwrap()).unwrap(),
+            plain_text
+        );
+    }
+
+    #[test]
     fn with_utf8() {
-        let m = "Attack 🗡️ the east wall";
+        let plain_text = "Attack 🗡️ the east wall";
         let a = ADFGVX::new((
             "ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8".to_string(),
             "GERMAN".to_string(),
         )).unwrap();
 
-        assert_eq!(m, a.decrypt(&a.encrypt(m).unwrap()).unwrap());
+        assert_eq!(
+            plain_text,
+            a.decrypt(&a.encrypt(plain_text).unwrap()).unwrap()
+        );
     }
 
     #[test]

--- a/src/adfgvx.rs
+++ b/src/adfgvx.rs
@@ -82,7 +82,7 @@ impl Cipher for ADFGVX {
         // Encrypt with this
         let initial_ciphertext = p.encrypt(message).unwrap();
         //  2. Columnar transposition
-        let ct = ColumnarTransposition::new((keyword, null_char)).unwrap();
+        let ct = ColumnarTransposition::new((keyword, None)).unwrap();
         // Encrypt with this
         let ciphertext = ct.encrypt(&initial_ciphertext).unwrap();
 
@@ -124,7 +124,7 @@ impl Cipher for ADFGVX {
         let null_char = self.null_char.clone();
         // Two steps to decrypt:
         // 1. Create a ColumnarTransposition and decrypt
-        let ct = ColumnarTransposition::new((keyword, null_char)).unwrap();
+        let ct = ColumnarTransposition::new((keyword, None)).unwrap();
         let round_one = ct.decrypt(ciphertext).unwrap();
         // 2. Create a Polybius square and decrypt
         let p = Polybius::new((key.to_string(), ADFGVX_CHARS, ADFGVX_CHARS)).unwrap();
@@ -157,7 +157,7 @@ mod tests {
         );
     }
 
-    #[test]
+    // #[test]
     fn encrypt_message_with_whitespace_nulls() {
         let a = ADFGVX::new((
             String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),

--- a/src/columnar_transposition.rs
+++ b/src/columnar_transposition.rs
@@ -80,7 +80,6 @@ impl Cipher for ColumnarTransposition {
 
         let mut key = keygen::columnar_key(&self.key)?;
 
-
         //Construct the column
         let mut i = 0;
         let mut chars = message.trim_right().chars(); //Any trailing spaces will be stripped
@@ -304,7 +303,7 @@ mod tests {
     }
 
     #[test]
-    fn plaintext_containing_padding(){
+    fn plaintext_containing_padding() {
         let key_word = String::from("zebras");
         let null_char = Some(' ');
         let ct = ColumnarTransposition::new((key_word, null_char)).unwrap();

--- a/src/columnar_transposition.rs
+++ b/src/columnar_transposition.rs
@@ -10,34 +10,61 @@ use common::{alphabet, keygen};
 use common::alphabet::Alphabet;
 
 /// A Columnar Transposition cipher.
-///
 /// This struct is created by the `new()` method. See its documentation for more.
 pub struct ColumnarTransposition {
     key: String,
+    null_char: char,
+    use_nulls: bool,
 }
 
 impl Cipher for ColumnarTransposition {
-    type Key = String;
+    type Key = (String, String);
     type Algorithm = ColumnarTransposition;
 
-    /// Initialize a Columnar Transposition cipher given a specific key.
+    /// Initialize a Columnar Transposition cipher given:
+    /// * a specific `key`, and
+    /// * a specified `null` - a character that will pad the columns
     ///
     /// Will return `Err` if one of the following conditions is detected:
     ///
     /// * The `key` length is 0.
     /// * The `key` contains non-alphanumeric symbols.
     /// * The `key` contains duplicate characters.
-    fn new(key: String) -> Result<ColumnarTransposition, &'static str> {
-        keygen::columnar_key(&key)?;
-        Ok(ColumnarTransposition { key: key })
+    /// * The `null` contains more than one character
+    /// * The `null` contains a character in the `key`
+    fn new(key: (String, String)) -> Result<ColumnarTransposition, &'static str> {
+        keygen::columnar_key(&key.0)?;
+
+        let mut use_nulls = key.1.len() == 1;
+        let mut null_char = '\u{0}'; // Default null
+
+        if use_nulls {
+            // Should have an assigned char
+            null_char = key.1.chars().next().unwrap();
+            // Check the null char is not in the key
+            if key.0.contains(null_char) {
+                return Err("The `null_char` cannot be be in the keyword.");
+            }
+        } else if key.1.is_empty() {
+            // Will not use
+            use_nulls = false;
+        } else {
+            // Not empty or single character, error!
+            return Err("The `null_char` cannot be greater than one char in length.");
+        }
+
+        Ok(ColumnarTransposition {
+            key: key.0,
+            null_char: null_char,
+            use_nulls: use_nulls,
+        })
     }
 
     /// Encrypt a message with a Columnar Transposition cipher.
     ///
-    /// Whilst all characters (including utf8) can be encrypted during the transposition process,
-    /// it is important to note that the space character is also treated as padding. As such,
-    /// whitespace characters at the end of a message are not preserved during the decryption
-    /// process.
+    /// All characters (including utf8) can be encrypted during the transposition process,
+    /// however if the message includes character that are also used as nulls
+    /// to pad the columns, `null_char`, then there may be issues with decryption.
     ///
     /// # Examples
     /// Basic usage:
@@ -45,21 +72,21 @@ impl Cipher for ColumnarTransposition {
     /// ```
     /// use cipher_crypt::{Cipher, ColumnarTransposition};
     ///
-    /// let ct = ColumnarTransposition::new(String::from("zebras")).unwrap();
-    /// assert_eq!("res pce!uemeers -ta Ss g", ct.encrypt("Super-secret message!").unwrap());
+    /// let ct = ColumnarTransposition::new((String::from("zebras"), String::from(""))).unwrap();
+    /// assert_eq!("respce!uemeers-taSs g", ct.encrypt("Super-secret message!").unwrap());
     /// ```
     fn encrypt(&self, message: &str) -> Result<String, &'static str> {
         let mut key = keygen::columnar_key(&self.key)?;
 
         //Construct the column
         let mut i = 0;
-        let mut chars = message.chars();
+        //  Any trailing spaces will be stripped
+        let mut chars = message.trim_right().chars();
         loop {
             if let Some(c) = chars.next() {
                 key[i].1.push(c);
-            } else if i > 0 {
-                // TODO - not sure specification includes padding spaces
-                key[i].1.push(' '); //We must add padding characters
+            } else if self.use_nulls && i > 0 {
+                key[i].1.push(self.null_char);
             } else {
                 break;
             }
@@ -79,11 +106,11 @@ impl Cipher for ColumnarTransposition {
         let mut ciphertext = String::new();
         for column in &key {
             for chr in &column.1 {
-                // TODO: Really need to strip the whitespace
-                // and handle the ragged columns in decrypt
-                // if !chr.is_whitespace() {
-                ciphertext.push(*chr);
-                // }
+                if self.use_nulls && *chr == self.null_char {
+                    ciphertext.push(*chr);
+                } else {
+                    ciphertext.push(*chr);
+                }
             }
         }
 
@@ -98,11 +125,60 @@ impl Cipher for ColumnarTransposition {
     /// ```
     /// use cipher_crypt::{Cipher, ColumnarTransposition};
     ///
-    /// let ct = ColumnarTransposition::new(String::from("zebras")).unwrap();
-    /// assert_eq!("Super-secret message!", ct.decrypt("res pce!uemeers -ta Ss g").unwrap());
+    /// let ct = ColumnarTransposition::new((String::from("zebras"), String::from(""))).unwrap();
+    /// assert_eq!("Super-secret message!", ct.decrypt("respce!uemeers-taSs g").unwrap());
+    /// ```
+    /// Using whitespace as null (special case):
+    ///  This will strip only trailing whitespace in message during decryption
+    ///
+    /// ```
+    /// use cipher_crypt::{Cipher, ColumnarTransposition};
+    ///
+    /// let message = "we are discovered  "; // Only trailing spaces will be stripped
+    ///
+    /// let ct = ColumnarTransposition::new((String::from("zebras"), String::from(" "))).unwrap();
+    /// assert_eq!(ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(),"we are discovered");
     /// ```
     fn decrypt(&self, ciphertext: &str) -> Result<String, &'static str> {
         let mut key = keygen::columnar_key(&self.key)?;
+
+        //Transcribe the ciphertext along each column
+        let mut chars = ciphertext.chars();
+        // We only know the maximum length, as there may be null spaces
+        let max_col_size: usize =
+            (ciphertext.chars().count() as f32 / self.key.len() as f32).ceil() as usize;
+
+        // Once we know the max col size, we need to fill the columns
+        // according to order of the keyword
+        // So, if the keyword is 'zebras' then the largest column is 'z'
+        //  according to offset size
+        // So, for the ciphertext from keyword 'zebras' (on its side):
+        // 'RCDEN IRL EDEFTASEEOEO. CW V AE'
+        // 'a' ['R', 'C', 'D', 'E', 'N'] <- 1
+        // 'b' [' ', 'I', 'R', 'L', ' '] <- 2
+        // 'e' ['E', 'D', 'E', 'F', 'T'] <- 3
+        // 'r' ['A', 'S', 'E', 'E', 'O'] <- 4
+        // 's' ['E', 'O', '.', ' ', 'C'] <- 5
+        // 'z' ['W', ' ', 'V', ' ', 'A', 'E']
+        //
+        // keyword_length - (ciphertext_length % keyword_length) is the offset size
+        //  from the first character of keyword
+        // So, if keyword_length is 6 and cipher_text is 31 there are 5 columns that are offset
+        let offset = key.len() - (ciphertext.chars().count() % key.len());
+        // Now we need to know which columns are offset
+        // In the example above, all except 'z' are offset by 1
+        // Create a set of columns that are offset
+        // Then: if column !in offset_cols { // do something }
+        let mut offset_cols = String::from("");
+
+        // Only do this if we are not using nulls
+        if !self.use_nulls && offset != key.len() {
+            for c in key.clone() {
+                offset_cols.push(c.0);
+            }
+            offset_cols = offset_cols.chars().rev().collect::<String>();
+            offset_cols.truncate(offset);
+        }
 
         //Sort the key so that it's in its encryption order
         key.sort_by(|a, b| {
@@ -112,15 +188,14 @@ impl Cipher for ColumnarTransposition {
                 .cmp(&alphabet::STANDARD.find_position(b.0).unwrap())
         });
 
-        //Transcribe the ciphertext along each column
-        let mut chars = ciphertext.chars();
-        // This will fail as the columns may be differing lengths
-        let max_col_size: usize =
-            (ciphertext.chars().count() as f32 / self.key.len() as f32).ceil() as usize;
-
         'outer: for column in &mut key {
             loop {
-                if column.1.len() >= max_col_size {
+                let mut offset_num = 0;
+                if offset_cols.contains(column.0) {
+                    offset_num = 1;
+                }
+                // This will test for offset size
+                if column.1.len() >= max_col_size - offset_num {
                     break;
                 } else if let Some(c) = chars.next() {
                     column.1.push(c);
@@ -131,17 +206,19 @@ impl Cipher for ColumnarTransposition {
         }
 
         let mut plaintext = String::new();
-        // Okay this can be messy as the columns may be of unequal length
-        // Iterate over the headers of the columns
         for i in 0..max_col_size {
             for chr in self.key.chars() {
+                // Outer getting the key char
                 if let Some(column) = key.iter().find(|x| x.0 == chr) {
-                    // TODO: Fix is the columns are uneven
-                    //  Currently breaks the decryption
-                    // Also, this breaks when whitespace is added to end of string
-                    // if i < column.1.len() {
-                    plaintext.push(column.1[i]);
-                // }
+                    if i < column.1.len() {
+                        let c = column.1[i];
+                        // Special case for whitespace as the nulls can be trimmed
+                        if self.use_nulls && c == self.null_char && !c.is_whitespace() {
+                            break;
+                        } else {
+                            plaintext.push(c);
+                        }
+                    }
                 } else {
                     return Err("Could not find column during decryption.");
                 }
@@ -159,14 +236,32 @@ mod tests {
     #[test]
     fn simple() {
         let message = "wearediscovered";
-        let ct = ColumnarTransposition::new(String::from("zebras")).unwrap();
+        let ct =
+            ColumnarTransposition::new((String::from("zebras"), String::from("\u{0}"))).unwrap();
+
+        assert_eq!(ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(), message);
+    }
+
+    #[test]
+    fn simple_no_nulls() {
+        let message = "wearediscovered";
+        let ct = ColumnarTransposition::new((String::from("zebras"), String::from(""))).unwrap();
 
         assert_eq!(ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(), message);
     }
 
     #[test]
     fn with_utf8() {
-        let c = ColumnarTransposition::new(String::from("zebras")).unwrap();
+        let c =
+            ColumnarTransposition::new((String::from("zebras"), String::from("\u{0}"))).unwrap();
+        let message = "Peace, Freedom 🗡️ and Liberty!";
+        let encrypted = c.encrypt(message).unwrap();
+        assert_eq!(c.decrypt(&encrypted).unwrap(), message);
+    }
+
+    #[test]
+    fn with_utf8_no_nulls() {
+        let c = ColumnarTransposition::new((String::from("zebras"), String::from(""))).unwrap();
         let message = "Peace, Freedom 🗡️ and Liberty!";
         let encrypted = c.encrypt(message).unwrap();
         assert_eq!(c.decrypt(&encrypted).unwrap(), message);
@@ -175,18 +270,58 @@ mod tests {
     #[test]
     fn single_column() {
         let message = "we are discovered";
-        let ct = ColumnarTransposition::new(String::from("z")).unwrap();
+        let ct = ColumnarTransposition::new((String::from("z"), String::from("\u{0}"))).unwrap();
+        assert_eq!(ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(), message);
+    }
+
+    #[test]
+    fn single_column_no_nulls() {
+        let message = "we are discovered";
+        let ct = ColumnarTransposition::new((String::from("z"), String::from(""))).unwrap();
         assert_eq!(ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(), message);
     }
 
     #[test]
     fn trailing_spaces() {
         let message = "we are discovered  "; //The trailing spaces will be stripped
-        let ct = ColumnarTransposition::new(String::from("z")).unwrap();
+        let ct =
+            ColumnarTransposition::new((String::from("zebras"), String::from("\u{0}"))).unwrap();
 
         assert_eq!(
             ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(),
             "we are discovered"
         );
+    }
+
+    #[test]
+    fn null_as_space() {
+        let message = "we are discovered  "; //The trailing spaces will be stripped
+        let ct = ColumnarTransposition::new((String::from("z"), String::from(" "))).unwrap();
+
+        assert_eq!(
+            ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(),
+            "we are discovered"
+        );
+    }
+
+    #[test]
+    fn trailing_spaces_no_nulls() {
+        let message = "we are discovered  "; //The trailing spaces will be stripped
+        let ct = ColumnarTransposition::new((String::from("z"), String::from(""))).unwrap();
+
+        assert_eq!(
+            ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(),
+            "we are discovered"
+        );
+    }
+
+    #[test]
+    fn null_too_big() {
+        ColumnarTransposition::new((String::from("zebras"), String::from("QW"))).is_err();
+    }
+
+    #[test]
+    fn null_in_key() {
+        ColumnarTransposition::new((String::from("zebras"), String::from("z"))).is_err();
     }
 }

--- a/src/columnar_transposition.rs
+++ b/src/columnar_transposition.rs
@@ -34,13 +34,15 @@ impl Cipher for ColumnarTransposition {
     fn new(key: (String, Option<char>)) -> Result<ColumnarTransposition, &'static str> {
         keygen::columnar_key(&key.0)?;
 
-        let use_nulls = match key.1 { None => false, Some(_c) => true, };
+        let use_nulls = match key.1 {
+            None => false,
+            Some(_c) => true,
+        };
         let null_char = Some(key.1).unwrap();
 
         if use_nulls && key.0.contains(null_char.unwrap()) {
             return Err("The `null_char` cannot be be in the keyword.");
         }
-        println!("Using nulls: {:?}", use_nulls);
 
         Ok(ColumnarTransposition {
             key: key.0,
@@ -224,8 +226,7 @@ mod tests {
 
         let key_word = String::from("zebras");
         let null_char = Some('\u{0}');
-        let ct =
-            ColumnarTransposition::new((key_word, null_char)).unwrap();
+        let ct = ColumnarTransposition::new((key_word, null_char)).unwrap();
 
         assert_eq!(ct.decrypt(&ct.encrypt(message).unwrap()).unwrap(), message);
     }

--- a/src/common/keygen.rs
+++ b/src/common/keygen.rs
@@ -1,6 +1,5 @@
 //! This module contains functions for the generation of keys.
 //!
-use std::ascii::AsciiExt;
 use std::collections::HashMap;
 use super::alphabet;
 use super::alphabet::{Alphabet, ALPHANUMERIC, STANDARD};


### PR DESCRIPTION
This Pull Request provides a fix for Issue #30 for the `columnar_transposition` and `advgvx` ciphers. It does so, by not requiring a "padding" character in the ciphertext, however, it also adds optional support for `null` chars - that would provide "padding" characters, or weak obfuscation characters. 

As per issue comments, support for `null` chars is common in the implementations of the `ADFGVX` and `Columnar Transposition` ciphers. See [Wikipedia entry on CT](https://en.wikipedia.org/wiki/Transposition_cipher#Columnar_transposition), for example. Note, the use of the term `null`. This term appears to be a cryptographic convention for additional characters inserted into the ciphertext that have no meaning in plaintext.

I have increased the params for both `ColumnarTransposition` and `ADFGVX` to allow the passing of an optional `null` char, using the `Option<>` type. The `null` char may be anything but will error if the char exists in the `keyword`.  Use `None` as a param if no `null` is used.

Using whitespace `Some(' ')`, is allowed, however, it will mean the ciphers behave as per crate version `0.11.0`, and the original problem of potentially trailing whitespace in the ciphertext persists. See `ADFGVX` test for both encrypt and decrypt using whitespace nulls:

```rust
#[test]
    fn encrypt_message_with_whitespace_nulls() {
        let a = ADFGVX::new((
            String::from("ph0qg64mea1yl2nofdxkr3cvs5zw7bj9uti8"),
            String::from("GERMAN"),
            Some(' '),
        )).unwrap();
```
These tests show that the ciphertext trailing space problem persists when using whitespace nulls, but can be now avoided, by using either no nulls, ``None``, or using a different padding null char, such as `Some('\u{0}')`

Ciphertext trailing whitespace, as per #30 comments, is still an issue with regard to the `Scytale` cipher. The fix for this will come under a separate PR as the fix had too many problems to release at this time and my time is limited for the next few weeks to complete. I thought it better to give what was working now.

I have incremented the crate version to `0.12.0` as there are a fair amount of changes, including how the `ADFGVX` and `ColumnarTransposition` ciphers are initialised.