### PR TITLE
Right-trim ciphertext for issue #33

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher-crypt"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["arosspope <andrew.pope456@gmail.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/arosspope/cipher-crypt.git"

--- a/src/scytale.rs
+++ b/src/scytale.rs
@@ -76,8 +76,8 @@ impl Cipher for Scytale {
                 ciphertext.push(table[col][row]);
             }
         }
-
-        Ok(ciphertext)
+        // Trim off any trailing whitespace added
+        Ok(ciphertext.trim_right().to_string())
     }
 
     /// Decrypt a message using a Scytale cipher.
@@ -172,6 +172,19 @@ mod tests {
     fn longer_height() {
         let s = Scytale::new(20).unwrap();
         let m = "attackatdawn";
+        assert_eq!(m, s.decrypt(&s.encrypt(m).unwrap()).unwrap());
+    }
+
+    #[test]
+    fn longer_msg() {
+        let s = Scytale::new(7).unwrap();
+        let m = concat!(
+            "We attack at dawn, not later when it is light, ",
+            "or at some strange time of the clock. Only at dawn. ",
+            "Why do we like to attack at dawn, actually, I don\'t ",
+            "get it. I hate getting up that early, it puts me in ",
+            "a bad mood. Can\'t we do it a bit later, say nine-thirty?"
+        );
         assert_eq!(m, s.decrypt(&s.encrypt(m).unwrap()).unwrap());
     }
 }


### PR DESCRIPTION
Actually, a __very__ easy fix for Issue #33  - just right-trim on the ciphertext!

I've tried all manner of combinations of message and height, Nothing else is required.

Please ignore commit message where I state `left-trim`... :roll_eyes: 