### PR TITLE
Baconian - courtesy of Sir Thomas

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: rust
 rust:
   - stable
 script:
-  - rustup install nightly
-  - rustup component add rustfmt-preview --toolchain=nightly
-  - cargo +nightly fmt -- --write-mode=diff
+  - rustup component add rustfmt-preview
+  - cargo fmt -- --write-mode=diff
   - cargo test --release --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,5 +17,6 @@ name = "cipher_crypt"
 [dependencies]
 lazy_static = "*"
 maplit = "*"
+lipsum = "0.4"
 num = "^0.1"
 rulinalg = "^0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher-crypt"
-version = "0.13"
+version = "0.13.0"
 authors = ["arosspope <andrew.pope456@gmail.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/arosspope/cipher-crypt.git"
@@ -15,5 +15,7 @@ documentation = "https://docs.rs/cipher-crypt/"
 name = "cipher_crypt"
 
 [dependencies]
+lazy_static = "*"
+maplit = "*"
 num = "^0.1"
 rulinalg = "^0.4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "cipher-crypt"
-version = "0.12.1"
+version = "0.13"
 authors = ["arosspope <andrew.pope456@gmail.com>"]
 license = "MIT/Apache-2.0"
 homepage = "https://github.com/arosspope/cipher-crypt.git"

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ adding the following to your Cargo.toml:
 
 ```toml
 [dependencies]
-cipher-crypt = "^0.12"
+cipher-crypt = "^0.13"
 ```
 
 Using the crate as such:
@@ -36,7 +36,7 @@ The crypt only contains a few ciphers, but with time (and your help) it will hav
 - [x] Fractionated Morse
 - [x] Columnar Transposition
 - [x] ADFGVX
-- [ ] Baconian
+- [x] Baconian
 - [ ] Porta
 - [ ] Homophonic
 - [ ] Four-Square

--- a/src/baconian.rs
+++ b/src/baconian.rs
@@ -5,22 +5,18 @@
 //! Each character of the plaintext message is encoded as a 5-bit binary character.
 //! These characters are then "hidden" in a decoy message through the use of font variation.
 //! This cipher is very easy to crack once the method of hiding is known. As such, this implementation includes
-//! the option to set whether the substitution is distinct for the whole alphabet,
+//! the option to set whether the substitution is use_distinct_alphabet for the whole alphabet,
 //! or whether it follows the classical method of treating 'I' and 'J', and 'U' and 'V' as
 //! interchangeable characters - as would have been the case in Bacon's time.
 //!
 //! If no concealing text is given and the boilerplate of "Lorem ipsum..." is used,
-//! a plaintext message of up to 50 characters may be hidden.
+//! a plaintext message of up to ~50 characters may be hidden.
 //!
 use std::collections::HashMap;
 use std::string::String;
 use common::cipher::Cipher;
+use lipsum::lipsum;
 
-/// Default decoy plaintext
-const DEFAULT_DECOY: &str =
-    "Lorem ipsum dolor sit amet, ne tamquam eruditi splendide vix. \
-     Mea vitae latine philosophia in, et qui gubergren definiebas. \
-     Est et debet aliquam. Ei velit augue quo, quod veniam definitionem nam ut.";
 /// The default code length
 const CODE_LEN: usize = 5;
 
@@ -119,12 +115,12 @@ lazy_static! {
 }
 
 /// Get the code for a given key (source character)
-fn get_code(distinct: bool, key: &str) -> String {
+fn get_code(use_distinct_alphabet: bool, key: &str) -> String {
     let mut code = String::new();
     // Need to handle 'I'/'J' and 'U'/'V'
     //  for traditional usage.
     let mut key_upper = key.to_uppercase();
-    if !distinct {
+    if !use_distinct_alphabet {
         match key_upper.as_str() {
             "J" => key_upper = "I".to_string(),
             "U" => key_upper = "V".to_string(),
@@ -151,7 +147,7 @@ fn get_key(code: &str) -> String {
 
 /// This struct is created by the `new()` method. See its documentation for more.
 pub struct Baconian {
-    distinct: bool,
+    use_distinct_alphabet: bool,
     decoy_text: String,
 }
 
@@ -163,19 +159,19 @@ impl Cipher for Baconian {
     ///
     /// The `key` tuple maps to the following:
     ///     `(bool, Option<str>) =
-    ///         (distinct, decoy_text)`.
+    ///         (use_distinct_alphabet, decoy_text)`.
     ///
     /// Where ...
     ///
-    /// * The encoding will be distinct for all alphabetical characters, or classical
+    /// * The encoding will be use_distinct_alphabet for all alphabetical characters, or classical
     ///     where I, J, U and V are mapped to the same value pairs
     /// * An optional decoy message that will will be used to hide the message -
     ///     default is boilerplate "Lorem ipsum" text.
     ///
     fn new(key: (bool, Option<String>)) -> Result<Baconian, &'static str> {
         Ok(Baconian {
-            distinct: key.0,
-            decoy_text: key.1.unwrap_or_else(|| String::from(DEFAULT_DECOY)),
+            use_distinct_alphabet: key.0,
+            decoy_text: key.1.unwrap_or_else(|| lipsum(160)),
         })
     }
 
@@ -194,7 +190,7 @@ impl Cipher for Baconian {
     ///
     /// let b = Baconian::new((false, None)).unwrap();
     /// let message = "Hello";
-    /// let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰𝘳 s𝘪t 𝘢𝘮e𝘵, 𝘯𝘦 t";
+    /// let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰𝘳 s𝘪t 𝘢𝘮e𝘵, 𝘤𝘰n";
     ///
     /// assert_eq!(cipher_text, b.encrypt(message).unwrap());
     /// ```
@@ -213,18 +209,17 @@ impl Cipher for Baconian {
             return Err("Message too long for supplied decoy text.");
         }
 
+        // Complex: decoy_slice needs to = secret.len + num_non_alphabetical_chars
+        let mut decoy_slice = self.decoy_text.clone();
         let mut secret = String::new();
         // Iterate through the message encoding each char
         // Ignore non-alphabetical chars
         for c in message.chars() {
             // get code and add to secret
-            let mut key = String::new();
-            key.push(c);
-            secret += &get_code(self.distinct, &key);
+            let key = String::from(c.to_string());
+            secret += &get_code(self.use_distinct_alphabet, &key);
         }
 
-        // Complex: decoy_slice needs to = secret.len + num_non_alphabetical_chars
-        let mut decoy_slice = self.decoy_text.clone();
         let mut alphas = 0;
         non_alphas = 0;
         for c in self.decoy_text.chars() {
@@ -249,8 +244,8 @@ impl Cipher for Baconian {
                 match secret.remove(0) {
                     'B' => {
                         // match the binary 'B' and swap for italic
-                        let italic = ITALIC_CODES.get(c.to_string().as_str());
-                        decoy_msg.push(*italic.unwrap());
+                        let italic = *ITALIC_CODES.get(c.to_string().as_str()).unwrap();
+                        decoy_msg.push(italic);
                     }
                     _ => decoy_msg.push(c),
                 }
@@ -320,10 +315,10 @@ mod tests {
     fn encrypt_simple() {
         let b = Baconian::new((false, None)).unwrap();
         let message = "Hello";
-        let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰𝘳 s𝘪t 𝘢𝘮e𝘵, 𝘯𝘦 t";
+        let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰𝘳 s𝘪t 𝘢𝘮e𝘵, 𝘤𝘰n";
         assert_eq!(cipher_text, b.encrypt(message).unwrap());
     }
-    // Need to test that the traditional and distinct codes give different results
+    // Need to test that the traditional and use_distinct_alphabet codes give different results
     #[test]
     fn encrypt_trad_v_dist() {
         let b_trad = Baconian::new((false, None)).unwrap();
@@ -359,7 +354,7 @@ mod tests {
             𝐶ur𝘴t f𝘳om t𝘩𝘦 cr𝘢𝘥𝘭𝘦, and";
         assert_eq!(cipher_text, b.encrypt(message).unwrap());
     }
-    // distinct lexicon
+    // use_distinct_alphabet lexicon
     #[test]
     #[should_panic(expected = r#"Message too long for supplied decoy text."#)]
     fn encrypt_decoy_too_short() {
@@ -372,7 +367,7 @@ mod tests {
     }
 
     #[test]
-    fn encrypt_with_distinct_codeset() {
+    fn encrypt_with_use_distinct_alphabet_codeset() {
         let message = "Peace, Freedom 🗡️ and Liberty!";
         let decoy_text = String::from(
             // The Life of Man, verse 1

--- a/src/baconian.rs
+++ b/src/baconian.rs
@@ -1,18 +1,332 @@
+//! Bacon's cipher or the Baconian cipher is a method of steganography
+//! (a method of hiding a secret message as opposed to just a cipher) devised by Francis Bacon in 1605.
+//! A message is concealed in the presentation of text, rather than its content.
 //!
-//! Write about the cipher here
+//! Each character of the message plaintext is encoded as a 5-bit binary,
+//!  these are then "hidden" in a decoy message through the use of font variation.
 //!
+//! This cipher is very easy to crack, once the method of hiding is known, therefore this
+//! implementation includes the options to set whether the substitution is distinct for the whole
+//! alphabet, or whether it follows the classical method of treating 'I' and 'J', and 'U' and 'V'
+//! as interchangeable characters, as would have been the case in Bacon's time.
 //!
+//! Also, it allows the user to change the underlying binary
+//! character choice, this is traditionally 'a' and 'b', but optionally the user can choose any
+//! pair of characters.
 //!
+//! If no concealing text is given and boilerplate of "Loren ipsum..." is used, given the capacity
+//! to hide up to a 50 character plaintext.
+//!
+use std::collections::HashMap;
 use std::string::String;
 use common::cipher::Cipher;
 
+/// Default decoy plaintext
+const DEFAULT_DECOY: &'static str =
+    "Lorem ipsum dolor sit amet, ne tamquam eruditi splendide vix. \
+     Mea vitae latine philosophia in, et qui gubergren definiebas. \
+     Est et debet aliquam. Ei velit augue quo, quod veniam definitionem nam ut.";
+/// The default code length
+const CODE_LEN: usize = 5;
+
+/// A traditional code set that makes 'J' = 'I' and 'V' = 'U' as they had equivalent value in Bacon's day
+lazy_static! {
+    static ref TRAD_CODES: HashMap<&'static str, &'static str> = hashmap!{
+        "A" => "AAAAA",
+        "B" => "AAAAB",
+        "C" => "AAABA",
+        "D" => "AAABB",
+        "E" => "AABAA",
+        "F" => "AABAB",
+        "G" => "AABBA",
+        "H" => "AABBB",
+        "I" => "ABAAA",
+        "J" => "ABAAA",
+        "K" => "ABAAB",
+        "L" => "ABABA",
+        "M" => "ABABB",
+        "N" => "ABBAA",
+        "O" => "ABBAB",
+        "P" => "ABBBA",
+        "Q" => "ABBBB",
+        "R" => "BAAAA",
+        "S" => "BAAAB",
+        "T" => "BAABA",
+        "U" => "BAABB",
+        "V" => "BAABB",
+        "W" => "BABAA",
+        "X" => "BABAB",
+        "Y" => "BABBA",
+        "Z" => "BABBB",
+    };
+}
+
+/// A distinct code set that covers all of the alphabet
+lazy_static! {
+    static ref DISTINCT_CODES: HashMap<&'static str, &'static str> = hashmap!{
+        "A" => "AAAAA",
+        "B" => "AAAAB",
+        "C" => "AAABA",
+        "D" => "AAABB",
+        "E" => "AABAA",
+        "F" => "AABAB",
+        "G" => "AABBA",
+        "H" => "AABBB",
+        "I" => "ABAAA",
+        "J" => "ABAAB",
+        "K" => "ABABA",
+        "L" => "ABABB",
+        "M" => "ABBAA",
+        "N" => "ABBAB",
+        "O" => "ABBBA",
+        "P" => "ABBBB",
+        "Q" => "BAAAA",
+        "R" => "BAAAB",
+        "S" => "BAABA",
+        "T" => "BAABB",
+        "U" => "BABAA",
+        "V" => "BABAB",
+        "W" => "BABBA",
+        "X" => "BABBB",
+        "Y" => "BBAAA",
+        "Z" => "BBAAB"
+    };
+}
+
+/// A mapping of alphabet to italic UTF-8 italic codes
+lazy_static! {
+    static ref ITALIC_CODES: HashMap<&'static str, &'static str> = hashmap!{
+        // Using Mathematical Italic
+        "A" => "\u{1D434}",
+        "B" => "\u{1D435}",
+        "C" => "\u{1D436}",
+        "D" => "\u{1D437}",
+        "E" => "\u{1D438}",
+        "F" => "\u{1D439}",
+        "G" => "\u{1D43a}",
+        "H" => "\u{1D43b}",
+        "I" => "\u{1D43c}",
+        "J" => "\u{1D43d}",
+        "K" => "\u{1D43e}",
+        "L" => "\u{1D43f}",
+        "M" => "\u{1D440}",
+        "N" => "\u{1D441}",
+        "O" => "\u{1D442}",
+        "P" => "\u{1D443}",
+        "Q" => "\u{1D444}",
+        "R" => "\u{1D445}",
+        "S" => "\u{1D446}",
+        "T" => "\u{1D447}",
+        "U" => "\u{1D448}",
+        "V" => "\u{1D449}",
+        "W" => "\u{1D44a}",
+        "X" => "\u{1D44b}",
+        "Y" => "\u{1D44c}",
+        "Z" => "\u{1D44d}",
+        // Using Mathematical Sans-Serif Italic
+        "a" => "\u{1D622}",
+        "b" => "\u{1D623}",
+        "c" => "\u{1D624}",
+        "d" => "\u{1D625}",
+        "e" => "\u{1D626}",
+        "f" => "\u{1D627}",
+        "g" => "\u{1D628}",
+        "h" => "\u{1D629}",
+        "i" => "\u{1D62a}",
+        "j" => "\u{1D62b}",
+        "k" => "\u{1D62c}",
+        "l" => "\u{1D62d}",
+        "m" => "\u{1D62e}",
+        "n" => "\u{1D62f}",
+        "o" => "\u{1D630}",
+        "p" => "\u{1D631}",
+        "q" => "\u{1D632}",
+        "r" => "\u{1D633}",
+        "s" => "\u{1D634}",
+        "t" => "\u{1D635}",
+        "u" => "\u{1D636}",
+        "v" => "\u{1D637}",
+        "w" => "\u{1D638}",
+        "x" => "\u{1D639}",
+        "y" => "\u{1D63a}",
+        "z" => "\u{1D63b}"
+    };
+}
+
+/// Get the code for a given key (source character)
+fn get_code(distinct: bool, key: String) -> String {
+    let mut code = String::new();
+    if distinct {
+        if DISTINCT_CODES.contains_key(key.to_uppercase().as_str()) {
+            code.push_str(DISTINCT_CODES.get(key.to_uppercase().as_str()).unwrap());
+        }
+    } else {
+        if TRAD_CODES.contains_key(key.to_uppercase().as_str()) {
+            code.push_str(TRAD_CODES.get(key.to_uppercase().as_str()).unwrap());
+        }
+    }
+
+    code
+}
+
+/// Gets the key (the source character) for a given cipher text code
+fn get_key(distinct: bool, code: &String) -> String {
+    let mut key = String::new();
+
+    let codes = if distinct { DISTINCT_CODES.iter() } else { TRAD_CODES.iter() };
+    for (_key, val) in codes {
+        if val == &code {
+            key.push_str(_key);
+        }
+    }
+    key
+}
 
 /// This struct is created by the `new()` method. See its documentation for more.
 pub struct Baconian {
-    key: String,
+    distinct: bool,
+    decoy_text: String,
 }
 
 impl Cipher for Baconian {
-    type Key = (String, String, Option<char>);
+    type Key = (bool, Option<String>);
     type Algorithm = Baconian;
+
+    /// Initialise a Baconian cipher
+    ///
+    /// The `key` tuple maps to the following:
+    ///     `(bool, Option<str>) =
+    ///         (distinct, decoy_text)`.
+    ///
+    /// Where ...
+    ///
+    /// * whether the encoding will be distinct for all alphabetical characters, or classical
+    ///     where I, J, U and V are mapped to the same value pairs
+    /// * An optional decoy message that will will be used to hide the message -
+    ///     default is boilerplate "Lorem ipsum" text.
+    ///
+    fn new(key: (bool, Option<String>)) -> Result<Baconian, &'static str> {
+        Ok(Baconian {
+            distinct: key.0,
+            decoy_text: key.1.unwrap_or(String::from(DEFAULT_DECOY)),
+        })
+    }
+
+    /// Encrypt a message using the Baconian cipher
+    ///
+    /// send in the message to be encrypted,
+    ///  - check that against the length of the decoy_text, the decoy_text
+    ///  must be at least 4-times as long (each character of message is encoded by
+    ///  4 characters)
+    /// - slice the decoy_text to right length and make an Vec<String> of four chars
+    /// - each character of plaintext is then encoded (aaaa, aaab etc.)
+    /// - italicise each occurrance of the binary char, so for 'b' in the decoy_text,
+    ///     the final letter of the sequence is italicised.
+    ///
+    fn encrypt(&self, message: &str) -> Result<String, &'static str> {
+        let mut non_alphas = 0; // A counter for non_alphas
+
+        for c in self.decoy_text.chars() {
+            if !c.is_alphabetic() { non_alphas += 1; }
+        }
+        // Check whether the message fits in the decoy
+        // Note: that non-alphabetical characters will be skipped.
+        if (message.len() * CODE_LEN) > self.decoy_text.len() - non_alphas {
+                return Err("Message too long for supplied decoy text.");
+        }
+
+        let mut secret = String::new();
+        // Iterate through the message encoding each char
+        // Ignore non-alphabetical chars
+        for c in message.chars() {
+            // get code and add to secret
+            let mut key = String::new();
+            key.push(c);
+            secret += &get_code(self.distinct, key);
+        }
+        println!("Encoded message: {} of length: {}", secret, secret.len());
+
+        // Complex: decoy_slice needs to = secret.len + num_non_alphabetical_chars
+        let mut decoy_slice = self.decoy_text.clone();
+        let mut alphas = 0;
+        non_alphas = 0;
+        for c in self.decoy_text.chars() {
+            if c.is_alphabetic() { alphas += 1; } else { non_alphas += 1; }
+            if alphas == secret.len() { break; }
+        }
+        decoy_slice.truncate(alphas + non_alphas);
+        println! ("Decoy text used: {} of length: {}", decoy_slice, decoy_slice.len());
+
+        let mut decoy_msg = String::new();
+        for c in decoy_slice.chars() {
+            if c.is_alphabetic() {
+                let code = secret.remove(0); // reduce the secret
+                if code == 'B' {
+                    let italic = ITALIC_CODES.get(c.to_string().as_str());
+                    decoy_msg.push_str(italic.unwrap());
+                } else {
+                    decoy_msg.push(c);
+                }
+            } else {
+                decoy_msg.push(c);
+            }
+        }
+
+        Ok(decoy_msg)
+    }
+
+    /// Decrypt a message that was encrypted with the Baconian cipher
+    ///
+    ///
+    fn decrypt(&self, message: &str) -> Result<String, &'static str> {
+        println!("Baconian decrypt");
+        let mut plaintext = String::new();
+        let mut ciphertext = String::new();
+        let mut code = String::new();
+        // The message is decoy text
+        // Iterate through swapping any alphabetical chars found in the ITALIC_CODES
+        // set to be 'B', else 'A', skip anything else.
+        for c in message.chars() {
+            if c.is_alphabetic() {
+                let mut is_code = false;
+                for (_key, val) in ITALIC_CODES.iter() {
+                    if *val == c.to_string().as_str() {
+                        is_code = true;
+                        break;
+                    }
+                }
+                if is_code {
+                    ciphertext.push('B');
+                } else {
+                    ciphertext.push('A');
+                }
+            }
+        }
+        for c in ciphertext.chars() {
+            code.push(c);
+            // If we have the right length code
+            if code.len() == CODE_LEN {
+                // Look up the key from value
+                // Now check the state of the encoding
+                // if the character is a 'B' then we italicise the output char
+                // pop the decoy
+                // push into msg
+                plaintext += &get_key(self.distinct, &code);
+                // Reset
+                code.clear();
+            }
+        }
+        Ok(plaintext)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn create_new() {
+        let b = Baconian::new((None, false, None)).unwrap();
+        println!("Created new Baconian");
+    }
 }

--- a/src/baconian.rs
+++ b/src/baconian.rs
@@ -131,7 +131,6 @@ fn get_code(distinct: bool, key: &str) -> String {
             _ => {}
         }
     }
-    print!("{}", key_upper);
     if CODE_MAP.contains_key(key_upper.as_str()) {
         code.push_str(CODE_MAP.get(key_upper.as_str()).unwrap());
     }
@@ -144,8 +143,6 @@ fn get_key(code: &str) -> String {
 
     for (_key, val) in CODE_MAP.iter() {
         if val == &code {
-            print!("{}", _key);
-
             key.push_str(_key);
         }
     }
@@ -197,7 +194,7 @@ impl Cipher for Baconian {
     ///
     /// let b = Baconian::new((false, None)).unwrap();
     /// let message = "Hello";
-    /// let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰r s𝘪t 𝘢me𝘵, 𝘯e 𝘵";
+    /// let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰𝘳 s𝘪t 𝘢𝘮e𝘵, 𝘯𝘦 t";
     ///
     /// assert_eq!(cipher_text, b.encrypt(message).unwrap());
     /// ```
@@ -274,7 +271,7 @@ impl Cipher for Baconian {
     /// use cipher_crypt::{Cipher, Baconian};
     ///
     /// let b = Baconian::new((false, None)).unwrap();
-    /// let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰r s𝘪t 𝘢me𝘵, 𝘯e 𝘵";
+    /// let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰𝘳 s𝘪t 𝘢𝘮e𝘵, 𝘯𝘦 t";
     ///
     /// assert_eq!("HELLO", b.decrypt(cipher_text).unwrap());
     /// ```
@@ -323,8 +320,20 @@ mod tests {
     fn encrypt_simple() {
         let b = Baconian::new((false, None)).unwrap();
         let message = "Hello";
-        let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰r s𝘪t 𝘢me𝘵, 𝘯e 𝘵";
+        let cipher_text = "Lo𝘳𝘦𝘮 ip𝘴um d𝘰l𝘰𝘳 s𝘪t 𝘢𝘮e𝘵, 𝘯𝘦 t";
         assert_eq!(cipher_text, b.encrypt(message).unwrap());
+    }
+    // Need to test that the traditional and distinct codes give different results
+    #[test]
+    fn encrypt_trad_v_dist() {
+        let b_trad = Baconian::new((false, None)).unwrap();
+        let b_dist = Baconian::new((true, None)).unwrap();
+        let message = "I JADE YOU VERVENT UNICORN";
+
+        assert_ne!(
+            b_dist.encrypt(&message).unwrap(),
+            b_trad.encrypt(message).unwrap()
+        );
     }
 
     #[test]
@@ -345,9 +354,9 @@ mod tests {
         let b = Baconian::new((false, Some(decoy_text))).unwrap();
         let message = "Peace, Freedom 🗡️ and Liberty!";
         let cipher_text =
-            "T𝘩𝘦 𝘸orl𝘥's a bubble; an𝘥 the 𝘭ife o𝘧 m𝘢𝘯 less th𝘢n a sp𝘢n. \
-            In hi𝘴 𝘤o𝘯𝘤e𝘱t𝘪o𝘯 𝘸retche𝘥; 𝘧rom th𝘦 𝘸o𝘮b 𝘴o t𝘰 the tomb: \
-            𝐶ur𝘴t f𝘳om th𝘦 cr𝘢d𝘭e, 𝘢𝘯d";
+            "T𝘩𝘦 𝘸𝘰rl𝘥\'s a bubble; an𝘥 the 𝘭ife o𝘧 m𝘢𝘯 les𝘴 th𝘢n a sp𝘢n. \
+            In hi𝘴 𝘤o𝘯𝘤𝘦pt𝘪𝘰n wretche𝘥; 𝘧r𝘰m th𝘦 𝘸o𝘮b 𝘴𝘰 t𝘰 the tomb: \
+            𝐶ur𝘴t f𝘳om t𝘩𝘦 cr𝘢𝘥𝘭𝘦, and";
         assert_eq!(cipher_text, b.encrypt(message).unwrap());
     }
     // distinct lexicon
@@ -400,9 +409,9 @@ mod tests {
     fn decrypt_traditional() {
         let cipher_text =
             String::from(
-                "T𝘩e wor𝘭d's a bubble; an𝘥 𝘵he 𝘭if𝘦 o𝘧 𝘮an 𝘭𝘦s𝘴 𝘵ha𝘯 𝘢 𝘴pa𝘯. \
-                𝐼n h𝘪s c𝘰ncep𝘵io𝘯 𝘸re𝘵che𝘥; 𝘧ro𝘮 th𝘦 w𝘰mb 𝘴𝘰 t𝘰 𝘵he t𝘰mb: \
-                Curs𝘵 fr𝘰𝘮 t𝘩𝘦 cradl𝘦, 𝘢nd"
+                "T𝘩e wor𝘭d's a bubble; an𝘥 𝘵he 𝘭if𝘦 𝘰f man 𝘭𝘦𝘴s 𝘵h𝘢n 𝘢 𝘴p𝘢n. \
+                𝐼n h𝘪s c𝘰nce𝘱𝘵i𝘰n 𝘸re𝘵che𝘥; 𝘧r𝘰𝘮 th𝘦 𝘸𝘰m𝘣 s𝘰 t𝘰 𝘵h𝘦 t𝘰mb: \
+                Curs𝘵 fr𝘰𝘮 𝘵h𝘦 cra𝘥l𝘦, 𝘢n𝘥"
             );
         // Note: the substitution for 'I'/'J' and 'U'/'V'
         let message = "IIADEYOVVERVENTVNICORN";

--- a/src/baconian.rs
+++ b/src/baconian.rs
@@ -8,7 +8,8 @@
 //! This cipher is very easy to crack, once the method of hiding is known, therefore this
 //! implementation includes the options to set whether the substitution is distinct for the whole
 //! alphabet, or whether it follows the classical method of treating 'I' and 'J', and 'U' and 'V'
-//! as interchangeable characters, as would have been the case in Bacon's time.
+//! as interchangeable characters, as would have been the case in Bacon's time, though 'I' and 'V'
+//! were more common in text.
 //!
 //! Also, it allows the user to change the underlying binary
 //! character choice, this is traditionally 'a' and 'b', but optionally the user can choose any
@@ -29,8 +30,13 @@ const DEFAULT_DECOY: &str =
 /// The default code length
 const CODE_LEN: usize = 5;
 
-/// A traditional code set that makes 'J' = 'I' and 'V' = 'U'
+/// Code mappings:
+///  * note: that str is preferred over char as it cannot be guaranteed that
+///     there will be a single codepoint for a given character.
+
+/// A traditional code set that makes 'I' = 'J' and 'V' = 'U'
 ///     - as they had equivalent value in Bacon's day
+///     - generally, 'I' and 'V' were more common and used here
 lazy_static! {
     static ref TRAD_CODES: HashMap<&'static str, &'static str> = hashmap!{
         "A" => "AAAAA",
@@ -42,7 +48,6 @@ lazy_static! {
         "G" => "AABBA",
         "H" => "AABBB",
         "I" => "ABAAA",
-        "J" => "ABAAA",
         "K" => "ABAAB",
         "L" => "ABABA",
         "M" => "ABABB",
@@ -53,7 +58,6 @@ lazy_static! {
         "R" => "BAAAA",
         "S" => "BAAAB",
         "T" => "BAABA",
-        "U" => "BAABB",
         "V" => "BAABB",
         "W" => "BABAA",
         "X" => "BABAB",
@@ -96,61 +100,61 @@ lazy_static! {
 
 /// A mapping of alphabet to italic UTF-8 italic codes
 lazy_static! {
-    static ref ITALIC_CODES: HashMap<&'static str, &'static str> = hashmap!{
+    static ref ITALIC_CODES: HashMap<&'static str, char> = hashmap!{
         // Using Mathematical Italic
-        "A" => "\u{1D434}",
-        "B" => "\u{1D435}",
-        "C" => "\u{1D436}",
-        "D" => "\u{1D437}",
-        "E" => "\u{1D438}",
-        "F" => "\u{1D439}",
-        "G" => "\u{1D43a}",
-        "H" => "\u{1D43b}",
-        "I" => "\u{1D43c}",
-        "J" => "\u{1D43d}",
-        "K" => "\u{1D43e}",
-        "L" => "\u{1D43f}",
-        "M" => "\u{1D440}",
-        "N" => "\u{1D441}",
-        "O" => "\u{1D442}",
-        "P" => "\u{1D443}",
-        "Q" => "\u{1D444}",
-        "R" => "\u{1D445}",
-        "S" => "\u{1D446}",
-        "T" => "\u{1D447}",
-        "U" => "\u{1D448}",
-        "V" => "\u{1D449}",
-        "W" => "\u{1D44a}",
-        "X" => "\u{1D44b}",
-        "Y" => "\u{1D44c}",
-        "Z" => "\u{1D44d}",
+        "A" => '\u{1D434}',
+        "B" => '\u{1D435}',
+        "C" => '\u{1D436}',
+        "D" => '\u{1D437}',
+        "E" => '\u{1D438}',
+        "F" => '\u{1D439}',
+        "G" => '\u{1D43a}',
+        "H" => '\u{1D43b}',
+        "I" => '\u{1D43c}',
+        "J" => '\u{1D43d}',
+        "K" => '\u{1D43e}',
+        "L" => '\u{1D43f}',
+        "M" => '\u{1D440}',
+        "N" => '\u{1D441}',
+        "O" => '\u{1D442}',
+        "P" => '\u{1D443}',
+        "Q" => '\u{1D444}',
+        "R" => '\u{1D445}',
+        "S" => '\u{1D446}',
+        "T" => '\u{1D447}',
+        "U" => '\u{1D448}',
+        "V" => '\u{1D449}',
+        "W" => '\u{1D44a}',
+        "X" => '\u{1D44b}',
+        "Y" => '\u{1D44c}',
+        "Z" => '\u{1D44d}',
         // Using Mathematical Sans-Serif Italic
-        "a" => "\u{1D622}",
-        "b" => "\u{1D623}",
-        "c" => "\u{1D624}",
-        "d" => "\u{1D625}",
-        "e" => "\u{1D626}",
-        "f" => "\u{1D627}",
-        "g" => "\u{1D628}",
-        "h" => "\u{1D629}",
-        "i" => "\u{1D62a}",
-        "j" => "\u{1D62b}",
-        "k" => "\u{1D62c}",
-        "l" => "\u{1D62d}",
-        "m" => "\u{1D62e}",
-        "n" => "\u{1D62f}",
-        "o" => "\u{1D630}",
-        "p" => "\u{1D631}",
-        "q" => "\u{1D632}",
-        "r" => "\u{1D633}",
-        "s" => "\u{1D634}",
-        "t" => "\u{1D635}",
-        "u" => "\u{1D636}",
-        "v" => "\u{1D637}",
-        "w" => "\u{1D638}",
-        "x" => "\u{1D639}",
-        "y" => "\u{1D63a}",
-        "z" => "\u{1D63b}"
+        "a" => '\u{1D622}',
+        "b" => '\u{1D623}',
+        "c" => '\u{1D624}',
+        "d" => '\u{1D625}',
+        "e" => '\u{1D626}',
+        "f" => '\u{1D627}',
+        "g" => '\u{1D628}',
+        "h" => '\u{1D629}',
+        "i" => '\u{1D62a}',
+        "j" => '\u{1D62b}',
+        "k" => '\u{1D62c}',
+        "l" => '\u{1D62d}',
+        "m" => '\u{1D62e}',
+        "n" => '\u{1D62f}',
+        "o" => '\u{1D630}',
+        "p" => '\u{1D631}',
+        "q" => '\u{1D632}',
+        "r" => '\u{1D633}',
+        "s" => '\u{1D634}',
+        "t" => '\u{1D635}',
+        "u" => '\u{1D636}',
+        "v" => '\u{1D637}',
+        "w" => '\u{1D638}',
+        "x" => '\u{1D639}',
+        "y" => '\u{1D63a}',
+        "z" => '\u{1D63b}'
     };
 }
 
@@ -161,8 +165,18 @@ fn get_code(distinct: bool, key: &str) -> String {
         if DISTINCT_CODES.contains_key(key.to_uppercase().as_str()) {
             code.push_str(DISTINCT_CODES.get(key.to_uppercase().as_str()).unwrap());
         }
-    } else if TRAD_CODES.contains_key(key.to_uppercase().as_str()) {
-        code.push_str(TRAD_CODES.get(key.to_uppercase().as_str()).unwrap());
+    } else {
+        // Need to handle 'I'/'J' and 'U'/'V'
+        let mut key_upper = key.to_uppercase();
+
+        match key_upper.as_str() {
+            "J" => key_upper = "I".to_string(),
+            "U" => key_upper = "V".to_string(),
+            _ => {}
+        }
+        if TRAD_CODES.contains_key(key_upper.as_str()) {
+            code.push_str(TRAD_CODES.get(key_upper.as_str()).unwrap());
+        }
     }
 
     code
@@ -278,12 +292,12 @@ impl Cipher for Baconian {
         let mut decoy_msg = String::new();
         for c in decoy_slice.chars() {
             if c.is_alphabetic() {
-                let code = secret.remove(0); // reduce the secret
-                if code == 'B' {
-                    let italic = ITALIC_CODES.get(c.to_string().as_str());
-                    decoy_msg.push_str(italic.unwrap());
-                } else {
-                    decoy_msg.push(c);
+                match secret.remove(0) {
+                    'B' => {
+                        let italic = ITALIC_CODES.get(c.to_string().as_str());
+                        decoy_msg.push(*italic.unwrap());
+                    }
+                    _ => decoy_msg.push(c),
                 }
             } else {
                 decoy_msg.push(c);
@@ -319,7 +333,7 @@ impl Cipher for Baconian {
             if c.is_alphabetic() {
                 let mut is_code = false;
                 for (_key, val) in ITALIC_CODES.iter() {
-                    if *val == c.to_string().as_str() {
+                    if *val == c {
                         is_code = true;
                         break;
                     }
@@ -421,6 +435,33 @@ mod tests {
         let message = "ATTACK";
         let decoy_text = String::from("Let's compromise. Hold off the attack");
         let b = Baconian::new((true, Some(decoy_text))).unwrap();
+        assert_eq!(message, b.decrypt(&cipher_text).unwrap());
+    }
+
+    #[test]
+    fn decrypt_traditional() {
+        let cipher_text =
+            String::from(
+                "T𝘩e wor𝘭d's a bubble; an𝘥 𝘵he 𝘭if𝘦 o𝘧 𝘮an 𝘭𝘦s𝘴 𝘵ha𝘯 𝘢 𝘴pa𝘯. \
+                𝐼n h𝘪s c𝘰ncep𝘵io𝘯 𝘸re𝘵che𝘥; 𝘧ro𝘮 th𝘦 w𝘰mb 𝘴𝘰 t𝘰 𝘵he t𝘰mb: \
+                Curs𝘵 fr𝘰𝘮 t𝘩𝘦 cradl𝘦, 𝘢nd"
+            );
+        // Note: the substitution for 'I'/'J' and 'U'/'V'
+        let message = "IIADEYOVVERVENTVNICORN";
+        let decoy_text = String::from(
+            // The Life of Man, verse 1
+            "The world's a bubble; and the life of man less than a span. \
+             In his conception wretched; from the womb so to the tomb: \
+             Curst from the cradle, and brought up to years, with cares and fears. \
+             Who then to frail mortality shall trust, \
+             But limns the water, or but writes in dust. \
+             Yet, since with sorrow here we live oppress'd, what life is best? \
+             Courts are but only superficial schools to dandle fools: \
+             The rural parts are turn'd into a den of savage men: \
+             And where's a city from all vice so free, \
+             But may be term'd the worst of all the three?",
+        );
+        let b = Baconian::new((false, Some(decoy_text))).unwrap();
         assert_eq!(message, b.decrypt(&cipher_text).unwrap());
     }
 }

--- a/src/baconian.rs
+++ b/src/baconian.rs
@@ -1,0 +1,18 @@
+//!
+//! Write about the cipher here
+//!
+//!
+//!
+use std::string::String;
+use common::cipher::Cipher;
+
+
+/// This struct is created by the `new()` method. See its documentation for more.
+pub struct Baconian {
+    key: String,
+}
+
+impl Cipher for Baconian {
+    type Key = (String, String, Option<char>);
+    type Algorithm = Baconian;
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,6 +27,7 @@ extern crate rulinalg;
 
 #[macro_use]
 extern crate lazy_static;
+extern crate lipsum;
 #[macro_use]
 extern crate maplit;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,6 +38,7 @@ pub mod polybius;
 pub mod scytale;
 pub mod columnar_transposition;
 pub mod adfgvx;
+pub mod baconian;
 
 pub use common::cipher::Cipher;
 pub use caesar::Caesar;
@@ -51,4 +52,5 @@ pub use affine::Affine;
 pub use polybius::Polybius;
 pub use scytale::Scytale;
 pub use columnar_transposition::ColumnarTransposition;
-pub use adfgvx::ADFGVX;
+pub use adfgvx::AADFGVX;
+pub use baconian::Baconian;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,11 @@
 extern crate num;
 extern crate rulinalg;
 
+#[macro_use]
+extern crate lazy_static;
+#[macro_use]
+extern crate maplit;
+
 mod common;
 pub mod caesar;
 pub mod vigenere;
@@ -52,5 +57,5 @@ pub use affine::Affine;
 pub use polybius::Polybius;
 pub use scytale::Scytale;
 pub use columnar_transposition::ColumnarTransposition;
-pub use adfgvx::AADFGVX;
+pub use adfgvx::ADFGVX;
 pub use baconian::Baconian;


### PR DESCRIPTION
This was a fun one!

Under the hood, it uses a simple substitution cipher, mapping alphabetical characters to 5-bit binary equivalents - so 'a' maps to `AAAAA`, 'b' to `AAAAB` and so on.
There are two code mappings, traditional that maps 'I' and 'J' to the same value, and 'U' and 'V' to the same. This was due to the fact in Elizabethan England, these were variants of the same character and not distinct, as they are today. I also added a distinct mapping that has a full alphabet mapped to discrete values.

Next, the fun part: hiding the produced substitution ciphertext in a decoy text. I do this by mapping alphabetical characters to italics if the binary is given. I use the mathematical italic `utf-8` characters. There maybe other fonts or characters that could be used, if so the code would need to be modularised.

Please have a look at the code and check for newbie `Rust` issues and feedback for me to fix. 