### PR TITLE
Fix rustfmt problems

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,5 +3,5 @@ rust:
   - stable
 script:
   - rustup component add rustfmt-preview
-  - cargo fmt -- --write-mode=diff
+  - cargo fmt -- --check
   - cargo test --release --verbose

--- a/src/adfgvx.rs
+++ b/src/adfgvx.rs
@@ -3,11 +3,11 @@
 //! ADFGVX was an extension of an earlier cipher called ADFGX. It uses a polybius square and a
 //! columnar transposition cipher.
 //!
-use Polybius;
 use columnar_transposition::ColumnarTransposition;
 use common::cipher::Cipher;
 use common::{alphabet, keygen};
 use std::string::String;
+use Polybius;
 
 const ADFGVX_CHARS: [char; 6] = ['A', 'D', 'F', 'G', 'V', 'X'];
 

--- a/src/autokey.rs
+++ b/src/autokey.rs
@@ -187,9 +187,7 @@ mod tests {
         let v = Autokey::new(String::from("lemon")).unwrap();
 
         assert_eq!(
-            vec![
-                'l', 'e', 'm', 'o', 'n', 'W', 'e', 'a', 'r', 'e', 'u', 'n', 'd', 'e', 'r'
-            ],
+            vec!['l', 'e', 'm', 'o', 'n', 'W', 'e', 'a', 'r', 'e', 'u', 'n', 'd', 'e', 'r'],
             v.encrypt_keystream(message)
         );
     }

--- a/src/hill.rs
+++ b/src/hill.rs
@@ -61,7 +61,8 @@ impl Cipher for Hill {
 
         //We want to restrict the caller to supplying matrices of type isize
         //However, the majority of the matrix operations will be done with type f64
-        let m: Matrix<f64> = key.clone()
+        let m: Matrix<f64> = key
+            .clone()
             .try_into()
             .expect("Could not convert Matrix of type `isize` to `f64`.");
 
@@ -277,10 +278,12 @@ impl Hill {
         //e.g. ['A', 'T', 'T'] -> [0, 19, 19]
         let mut index_representation: Vec<f64> = Vec::new();
         for c in chunk.chars() {
-            index_representation.push(alphabet::STANDARD
-                .find_position(c)
-                .expect("Attempted transformation of non-alphabetic symbol")
-                as f64);
+            index_representation.push(
+                alphabet::STANDARD
+                    .find_position(c)
+                    .expect("Attempted transformation of non-alphabetic symbol")
+                    as f64,
+            );
         }
 
         //Perform the transformation `k * [0, 19, 19] mod 26`

--- a/src/vigenere.rs
+++ b/src/vigenere.rs
@@ -144,9 +144,7 @@ mod tests {
         let v = Vigenere::new(String::from("lemon")).unwrap(); //key length of 5
 
         assert_eq!(
-            vec![
-                'l', 'e', 'm', 'o', 'n', 'l', 'e', 'm', 'o', 'n', 'l', 'e', 'm', 'o', 'n'
-            ],
+            vec!['l', 'e', 'm', 'o', 'n', 'l', 'e', 'm', 'o', 'n', 'l', 'e', 'm', 'o', 'n'],
             v.keystream(message)
         );
     }


### PR DESCRIPTION
This PR fixes two problems with the current code related to rustfmt:
- The Travis config still uses the `--write-mode` rustfmt command line option which has been replaced with the `--check` flag in the current version of rustfmt.
- The rustfmt check fails with the current version of rustfmt, probably because some format rules were updated recently.