### PR TITLE
Update lipsum to version 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,6 @@ name = "cipher_crypt"
 [dependencies]
 lazy_static = "^1"
 maplit = "^1.0.1"
-lipsum = "^0.4"
+lipsum = "^0.6"
 num = "^0.1"
 rulinalg = "^0.4"


### PR DESCRIPTION
This backwards-compatible version was released today.